### PR TITLE
chore(ci): Disable image push on build workflows

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -4,6 +4,9 @@ inputs:
   tags:
     type: string
     default: ${{ github.sha }}
+  image:
+    type: string
+    default: controller
 runs:
   using: "composite"
   steps:
@@ -18,5 +21,5 @@ runs:
       with:
         path_context: "."
         builder_image: "${{ steps.s2ibase.outputs.content }}"
-        image: peribolos-as-a-service
+        image: "${{ inputs.image }}"
         tags: "${{ inputs.tags }}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,4 +21,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        uses: ./.github/actions/build-controller
+        uses: ./.github/actions/build

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -16,8 +16,8 @@ jobs:
       - name: Test
         uses: ./.github/actions/test
 
-  build-controller:
-    name: Build and Push Controller
+  build:
+    name: Build and Push
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,51 +27,22 @@ jobs:
         uses: ./.github/actions/build-controller
         with:
           tags: ${{ github.sha }} latest
+      #     image: IMAGE
+      #
+      # - name: Push To Quay
+      #   uses: redhat-actions/push-to-registry@v2
+      #   if: ${{ github.repository == 'ORG/REPO'}}
+      #   with:
+      #     image: IMAGE
+      #     tags: ${{ github.sha }} latest
+      #     registry: quay.io/QUAY_ORG
+      #     username: ${{ secrets.QUAY_USERNAME }}
+      #     password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Push To Quay
-        uses: redhat-actions/push-to-registry@v2
-        if: ${{ github.repository == 'open-services-group/peribolos-as-a-service'}}
-        with:
-          image: peribolos-as-a-service
-          tags: ${{ github.sha }} latest
-          registry: quay.io/open-services-group
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Set expiration
-        uses: ./.github/actions/set-expiration
-        with:
-          repository: open-services-group/peribolos-as-a-service
-          tag: ${{ github.sha }}
-          expiration: +1 week
-          token: ${{ secrets.QUAY_OAUTH_TOKEN }}
-
-  build-peribolos:
-    name: Build and Push Peribolos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Build
-        uses: ./.github/actions/build-peribolos
-        with:
-          tags: ${{ github.sha }} latest
-
-      - name: Push To Quay
-        uses: redhat-actions/push-to-registry@v2
-        if: ${{ github.repository == 'open-services-group/peribolos-as-a-service'}}
-        with:
-          image: peribolos
-          tags: ${{ github.sha }} latest
-          registry: quay.io/open-services-group
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Set expiration
-        uses: ./.github/actions/set-expiration
-        with:
-          repository: open-services-group/peribolos
-          tag: ${{ github.sha }}
-          expiration: +1 week
-          token: ${{ secrets.QUAY_OAUTH_TOKEN }}
+      # - name: Set expiration
+      #   uses: ./.github/actions/set-expiration
+      #   with:
+      #     repository: QUAY_ORG/QUAY_REPO
+      #     tag: ${{ github.sha }}
+      #     expiration: +1 week
+      #     token: ${{ secrets.QUAY_OAUTH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build
         id: build
-        uses: ./.github/actions/build-controller
+        uses: ./.github/actions/build
 
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v2
@@ -166,7 +166,7 @@ jobs:
           ref: ${{ needs.release-to-git.outputs.tag }}
 
       - name: Build
-        uses: ./.github/actions/build-controller
+        uses: ./.github/actions/build
         id: build
         with:
           tags: ${{ github.sha }} ${{ needs.release-to-git.outputs.tag }}


### PR DESCRIPTION
This should disable image being pushed to Quay for the time being. Once we transfer this repository into operate-first we should enable it back again and make it push to `quay.io/operate-first/<something>`.